### PR TITLE
neovimにbarbar-nvimを追加

### DIFF
--- a/neovim/plugins/barbar-nvim.lua
+++ b/neovim/plugins/barbar-nvim.lua
@@ -1,0 +1,27 @@
+vim.g.barbar_auto_setup = true
+
+local map = vim.api.nvim_set_keymap
+local opts = { noremap = true, silent = true }
+
+map('n', '<A-,>', '<Cmd>BufferPrevious<CR>', opts)
+map('n', '<A-.>', '<Cmd>BufferNext<CR>', opts)
+map('n', '<A-<>', '<Cmd>BufferMovePrevious<CR>', opts)
+map('n', '<A->>', '<Cmd>BufferMoveNext<CR>', opts)
+map('n', '<A-1>', '<Cmd>BufferGoto 1<CR>', opts)
+map('n', '<A-2>', '<Cmd>BufferGoto 2<CR>', opts)
+map('n', '<A-3>', '<Cmd>BufferGoto 3<CR>', opts)
+map('n', '<A-4>', '<Cmd>BufferGoto 4<CR>', opts)
+map('n', '<A-5>', '<Cmd>BufferGoto 5<CR>', opts)
+map('n', '<A-6>', '<Cmd>BufferGoto 6<CR>', opts)
+map('n', '<A-7>', '<Cmd>BufferGoto 7<CR>', opts)
+map('n', '<A-8>', '<Cmd>BufferGoto 8<CR>', opts)
+map('n', '<A-9>', '<Cmd>BufferGoto 9<CR>', opts)
+map('n', '<A-0>', '<Cmd>BufferLast<CR>', opts)
+map('n', '<A-p>', '<Cmd>BufferPin<CR>', opts)
+map('n', '<A-c>', '<Cmd>BufferClose<CR>', opts)
+map('n', '<C-p>', '<Cmd>BufferPick<CR>', opts)
+map('n', '<Space>bb', '<Cmd>BufferOrderByBufferNumber<CR>', opts)
+map('n', '<Space>bd', '<Cmd>BufferOrderByDirectory<CR>', opts)
+map('n', '<Space>bl', '<Cmd>BufferOrderByLanguage<CR>', opts)
+map('n', '<Space>bw', '<Cmd>BufferOrderByWindowNumber<CR>', opts)
+

--- a/nix/alacritty.nix
+++ b/nix/alacritty.nix
@@ -43,6 +43,384 @@
       env = {
         TERM = "alacritty";
       };
+
+      key_bindings = [
+        {
+          key = "A";
+          mods = "Alt";
+          chars = "\\x1ba";
+        }
+        {
+          key = "B";
+          mods = "Alt";
+          chars = "\\x1bb";
+        }
+        {
+          key = "C";
+          mods = "Alt";
+          chars = "\\x1bc";
+        }
+        {
+          key = "D";
+          mods = "Alt";
+          chars = "\\x1bd";
+        }
+        {
+          key = "E";
+          mods = "Alt";
+          chars = "\\x1be";
+        }
+        {
+          key = "F";
+          mods = "Alt";
+          chars = "\\x1bf";
+        }
+        {
+          key = "G";
+          mods = "Alt";
+          chars = "\\x1bg";
+        }
+        {
+          key = "H";
+          mods = "Alt";
+          chars = "\\x1bh";
+        }
+        {
+          key = "I";
+          mods = "Alt";
+          chars = "\\x1bi";
+        }
+        {
+          key = "J";
+          mods = "Alt";
+          chars = "\\x1bj";
+        }
+        {
+          key = "K";
+          mods = "Alt";
+          chars = "\\x1bk";
+        }
+        {
+          key = "L";
+          mods = "Alt";
+          chars = "\\x1bl";
+        }
+        {
+          key = "M";
+          mods = "Alt";
+          chars = "\\x1bm";
+        }
+        {
+          key = "N";
+          mods = "Alt";
+          chars = "\\x1bn";
+        }
+        {
+          key = "O";
+          mods = "Alt";
+          chars = "\\x1bo";
+        }
+        {
+          key = "P";
+          mods = "Alt";
+          chars = "\\x1bp";
+        }
+        {
+          key = "Q";
+          mods = "Alt";
+          chars = "\\x1bq";
+        }
+        {
+          key = "R";
+          mods = "Alt";
+          chars = "\\x1br";
+        }
+        {
+          key = "S";
+          mods = "Alt";
+          chars = "\\x1bs";
+        }
+        {
+          key = "T";
+          mods = "Alt";
+          chars = "\\x1bt";
+        }
+        {
+          key = "U";
+          mods = "Alt";
+          chars = "\\x1bu";
+        }
+        {
+          key = "V";
+          mods = "Alt";
+          chars = "\\x1bv";
+        }
+        {
+          key = "W";
+          mods = "Alt";
+          chars = "\\x1bw";
+        }
+        {
+          key = "X";
+          mods = "Alt";
+          chars = "\\x1bx";
+        }
+        {
+          key = "Y";
+          mods = "Alt";
+          chars = "\\x1by";
+        }
+        {
+          key = "Z";
+          mods = "Alt";
+          chars = "\\x1bz";
+        }
+        {
+          key = "A";
+          mods = "Alt|Shift";
+          chars = "\\x1bA";
+        }
+        {
+          key = "B";
+          mods = "Alt|Shift";
+          chars = "\\x1bB";
+        }
+        {
+          key = "C";
+          mods = "Alt|Shift";
+          chars = "\\x1bC";
+        }
+        {
+          key = "D";
+          mods = "Alt|Shift";
+          chars = "\\x1bD";
+        }
+        {
+          key = "E";
+          mods = "Alt|Shift";
+          chars = "\\x1bE";
+        }
+        {
+          key = "F";
+          mods = "Alt|Shift";
+          chars = "\\x1bF";
+        }
+        {
+          key = "G";
+          mods = "Alt|Shift";
+          chars = "\\x1bG";
+        }
+        {
+          key = "H";
+          mods = "Alt|Shift";
+          chars = "\\x1bH";
+        }
+        {
+          key = "I";
+          mods = "Alt|Shift";
+          chars = "\\x1bI";
+        }
+        {
+          key = "J";
+          mods = "Alt|Shift";
+          chars = "\\x1bJ";
+        }
+        {
+          key = "K";
+          mods = "Alt|Shift";
+          chars = "\\x1bK";
+        }
+        {
+          key = "L";
+          mods = "Alt|Shift";
+          chars = "\\x1bL";
+        }
+        {
+          key = "M";
+          mods = "Alt|Shift";
+          chars = "\\x1bM";
+        }
+        {
+          key = "N";
+          mods = "Alt|Shift";
+          chars = "\\x1bN";
+        }
+        {
+          key = "O";
+          mods = "Alt|Shift";
+          chars = "\\x1bO";
+        }
+        {
+          key = "P";
+          mods = "Alt|Shift";
+          chars = "\\x1bP";
+        }
+        {
+          key = "Q";
+          mods = "Alt|Shift";
+          chars = "\\x1bQ";
+        }
+        {
+          key = "R";
+          mods = "Alt|Shift";
+          chars = "\\x1bR";
+        }
+        {
+          key = "S";
+          mods = "Alt|Shift";
+          chars = "\\x1bS";
+        }
+        {
+          key = "T";
+          mods = "Alt|Shift";
+          chars = "\\x1bT";
+        }
+        {
+          key = "U";
+          mods = "Alt|Shift";
+          chars = "\\x1bU";
+        }
+        {
+          key = "V";
+          mods = "Alt|Shift";
+          chars = "\\x1bV";
+        }
+        {
+          key = "W";
+          mods = "Alt|Shift";
+          chars = "\\x1bW";
+        }
+        {
+          key = "X";
+          mods = "Alt|Shift";
+          chars = "\\x1bX";
+        }
+        {
+          key = "Y";
+          mods = "Alt|Shift";
+          chars = "\\x1bY";
+        }
+        {
+          key = "Z";
+          mods = "Alt|Shift";
+          chars = "\\x1bZ";
+        }
+        {
+          key = "Key1";
+          mods = "Alt";
+          chars = "\\x1b1";
+        }
+        {
+          key = "Key2";
+          mods = "Alt";
+          chars = "\\x1b2";
+        }
+        {
+          key = "Key3";
+          mods = "Alt";
+          chars = "\\x1b3";
+        }
+        {
+          key = "Key4";
+          mods = "Alt";
+          chars = "\\x1b4";
+        }
+        {
+          key = "Key5";
+          mods = "Alt";
+          chars = "\\x1b5";
+        }
+        {
+          key = "Key6";
+          mods = "Alt";
+          chars = "\\x1b6";
+        }
+        {
+          key = "Key7";
+          mods = "Alt";
+          chars = "\\x1b7";
+        }
+        {
+          key = "Key8";
+          mods = "Alt";
+          chars = "\\x1b8";
+        }
+        {
+          key = "Key9";
+          mods = "Alt";
+          chars = "\\x1b9";
+        }
+        {
+          key = "Space";
+          mods = "Control";
+          chars = "\\x00";
+        }
+        {
+          key = "Grave";
+          mods = "Control";
+          chars = "\\x1b`";
+        }
+        {
+          key = "Grave";
+          mods = "Alt|Shift";
+          chars = "\\x1b~";
+        }
+        {
+          key = "Period";
+          mods = "Alt";
+          chars = "\\x1b.";
+        }
+        {
+          key = "Comma";
+          mods = "Alt";
+          chars = "\\x1b,";
+        }
+        {
+          key = "Key8";
+          mods = "Alt|Shift";
+          chars = "\\x1b*";
+        }
+        {
+          key = "Key3";
+          mods = "Alt|Shift";
+          chars = "\\x1b#";
+        }
+        {
+          key = "Period";
+          mods = "Alt|Shift";
+          chars = "\\x1b>";
+        }
+        {
+          key = "Comma";
+          mods = "Alt|Shift";
+          chars = "\\x1b<";
+        }
+        {
+          key = "Minus";
+          mods = "Alt|Shift";
+          chars = "\\x1b_";
+        }
+        {
+          key = "Key5";
+          mods = "Alt|Shift";
+          chars = "\\x1b%";
+        }
+        {
+          key = "Key6";
+          mods = "Alt|Shift";
+          chars = "\\x1b^";
+        }
+        {
+          key = "Backslash";
+          mods = "Alt";
+          chars = "\\x1b\\\\";
+        }
+        {
+          key = "Backslash";
+          mods = "Alt|Shift";
+          chars = "\\x1b|";
+        }
+      ];
     };
   };
 }

--- a/nix/neovim.nix
+++ b/nix/neovim.nix
@@ -53,6 +53,12 @@
         config = builtins.readFile ../neovim/plugins/nvim-lspconfig.lua;
       }
       lexima-vim
+      {
+        plugin = barbar-nvim;
+        type = "lua";
+        config = builtins.readFile ../neovim/plugins/barbar-nvim.lua;
+      }
+      nvim-web-devicons
     ];
   };
 }


### PR DESCRIPTION
barbar-nvimを追加した。macOSではOption keyがそれに当たるが、メタキーとしての役割を持っているのでAlacrittyへのキーバインドも追加した。
